### PR TITLE
Simulation stopping

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -55,7 +55,7 @@
 		<dependency>
 			<groupId>com.camunda.consulting</groupId>
 			<artifactId>camunda-bpm-simulator</artifactId>
-			<version>1.1.0-SNAPSHOT</version>
+			<version>1.3.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/com/camunda/consulting/simulator/SimulationExecutor.java
+++ b/src/main/java/com/camunda/consulting/simulator/SimulationExecutor.java
@@ -36,16 +36,6 @@ public class SimulationExecutor {
     return progress;
   }
 
-  private static boolean simulationStopped = false;
-
-  public static void stopSimulation(){
-    simulationStopped = true;
-  }
-  
-  public static void restartSimulation() {
-    simulationStopped = false;
-  }
-
   public static void execute(Date start, Date end) {
 
     ProcessEngineConfigurationImpl processEngineConfigurationImpl = SimulatorPlugin.getProcessEngineConfiguration();
@@ -84,7 +74,7 @@ public class SimulationExecutor {
             lastMetricUpdate = simulationTime;
             processEngineConfigurationImpl.getDbMetricsReporter().reportNow();
           }
-        } while (!simulationStopped && job.isPresent() && (job.get().getDuedate() == null || !job.get().getDuedate().after(end)));
+        } while (job.isPresent() && (job.get().getDuedate() == null || !job.get().getDuedate().after(end)));
 
         // get the next job that is due after current time and adjust clock to
         // its due date
@@ -92,8 +82,8 @@ public class SimulationExecutor {
         job.map(Job::getDuedate).ifPresent(ClockUtil::setCurrentTime);
         progress = Math.min(1, (ClockUtil.getCurrentTime().getTime() - start.getTime()) / (double) (end.getTime() - start.getTime()));
 
-          LOG.debug("Advance simulation time to: " + ClockUtil.getCurrentTime());
-        } while ( !simulationStopped && job.isPresent() && (job.get().getDuedate() == null || !job.get().getDuedate().after(end)));
+        LOG.debug("Advance simulation time to: " + ClockUtil.getCurrentTime());
+      } while (job.isPresent() && (job.get().getDuedate() == null || !job.get().getDuedate().after(end)));
     });
   }
 
@@ -124,7 +114,6 @@ public class SimulationExecutor {
     } finally {
       ClockUtil.reset();
       progress = 1;
-      simulationStopped = false;
 
       updateStartTimersForCurrentTime(commandExecutor);
 
@@ -178,6 +167,4 @@ public class SimulationExecutor {
     cal.add(Calendar.MILLISECOND, 1);
     ClockUtil.setCurrentTime(cal.getTime());
   }
-
-
 }

--- a/src/main/java/com/camunda/consulting/simulator/SimulationExecutor.java
+++ b/src/main/java/com/camunda/consulting/simulator/SimulationExecutor.java
@@ -51,22 +51,23 @@ public class SimulationExecutor {
     ProcessEngineConfigurationImpl processEngineConfigurationImpl = SimulatorPlugin.getProcessEngineConfiguration();
     ProcessEngine processEngine = SimulatorPlugin.getProcessEngine();
     CommandExecutor commandExecutor = processEngineConfigurationImpl.getCommandExecutorTxRequired();
-
-    runWithPreparedEngineConfiguration(processEngineConfigurationImpl, commandExecutor, () -> {
-
-      ClockUtil.setCurrentTime(start);
-      progress = 0;
-      LocalDateTime lastMetricUpdate = null;
-
-      updateStartTimersForCurrentTime(commandExecutor);
-
-      Optional<Job> job;
+    
+    if(!simulationStopped) {
+      runWithPreparedEngineConfiguration(processEngineConfigurationImpl, commandExecutor, () -> {
+        
+        ClockUtil.setCurrentTime(start);
+        progress = 0;
+        LocalDateTime lastMetricUpdate = null;
+        
+        updateStartTimersForCurrentTime(commandExecutor);
+        
+        Optional<Job> job;
         do {
           // execute all jobs that are due before current time
           do {
             // work around engine "bug"
             makeTimeGoBy();
-
+            
             // by setting the processEngineConfigurationImpl.setJobExecutor*
             // properties we can be sure to get the next job with minimum due date
             List<JobEntity> jobs = commandExecutor.execute(new Command<List<JobEntity>>() {
@@ -77,24 +78,25 @@ public class SimulationExecutor {
             });
             job = jobs.stream().map(jobEntity -> (Job) jobEntity).findFirst();
             job.map(Job::getId).ifPresent(processEngine.getManagementService()::executeJob);
-
-          // write metrics from time to time
-          final LocalDateTime simulationTime = ClockUtil.getCurrentTime().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
-          if (lastMetricUpdate == null || lastMetricUpdate.plusMinutes(METRIC_WRITE_INTERVAL_MINUTES).isBefore(simulationTime)) {
-            lastMetricUpdate = simulationTime;
-            processEngineConfigurationImpl.getDbMetricsReporter().reportNow();
-          }
-        } while (!simulationStopped && job.isPresent() && (job.get().getDuedate() == null || !job.get().getDuedate().after(end)));
-
-        // get the next job that is due after current time and adjust clock to
-        // its due date
-        job = processEngine.getManagementService().createJobQuery().active().withRetriesLeft().orderByJobDuedate().asc().listPage(0, 1).stream().findFirst();
-        job.map(Job::getDuedate).ifPresent(ClockUtil::setCurrentTime);
-        progress = Math.min(1, (ClockUtil.getCurrentTime().getTime() - start.getTime()) / (double) (end.getTime() - start.getTime()));
-
+            
+            // write metrics from time to time
+            final LocalDateTime simulationTime = ClockUtil.getCurrentTime().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
+            if (lastMetricUpdate == null || lastMetricUpdate.plusMinutes(METRIC_WRITE_INTERVAL_MINUTES).isBefore(simulationTime)) {
+              lastMetricUpdate = simulationTime;
+              processEngineConfigurationImpl.getDbMetricsReporter().reportNow();
+            }
+          } while (!simulationStopped && job.isPresent() && (job.get().getDuedate() == null || !job.get().getDuedate().after(end)));
+          
+          // get the next job that is due after current time and adjust clock to
+          // its due date
+          job = processEngine.getManagementService().createJobQuery().active().withRetriesLeft().orderByJobDuedate().asc().listPage(0, 1).stream().findFirst();
+          job.map(Job::getDuedate).ifPresent(ClockUtil::setCurrentTime);
+          progress = Math.min(1, (ClockUtil.getCurrentTime().getTime() - start.getTime()) / (double) (end.getTime() - start.getTime()));
+          
           LOG.debug("Advance simulation time to: " + ClockUtil.getCurrentTime());
         } while ( !simulationStopped && job.isPresent() && (job.get().getDuedate() == null || !job.get().getDuedate().after(end)));
-    });
+      });
+    }
   }
 
   private static void runWithPreparedEngineConfiguration(ProcessEngineConfigurationImpl processEngineConfigurationImpl, CommandExecutor commandExecutor,

--- a/src/main/java/com/camunda/consulting/simulator/SimulationExecutor.java
+++ b/src/main/java/com/camunda/consulting/simulator/SimulationExecutor.java
@@ -41,6 +41,10 @@ public class SimulationExecutor {
   public static void stopSimulation(){
     simulationStopped = true;
   }
+  
+  public static void restartSimulation() {
+    simulationStopped = false;
+  }
 
   public static void execute(Date start, Date end) {
 

--- a/src/main/java/com/camunda/consulting/simulator/SimulatorPlugin.java
+++ b/src/main/java/com/camunda/consulting/simulator/SimulatorPlugin.java
@@ -52,6 +52,24 @@ public class SimulatorPlugin implements ProcessEnginePlugin {
   public static ProcessEngine getProcessEngine() {
     return BpmPlatform.getDefaultProcessEngine();
   }
+  
+  public static void resetProcessEngineElements() {
+    ProcessEngineConfigurationImpl pimpl = getProcessEngineConfiguration();
+    
+    BpmnDeployer originalDeployer = new BpmnDeployer();
+    pimpl.getDeployers().removeIf(deployer -> {
+      if(deployer instanceof SimulatingBpmnDeployer) {
+        originalDeployer.setBpmnParser(((SimulatingBpmnDeployer) deployer).getBpmnParser());
+        originalDeployer.setExpressionManager(((SimulatingBpmnDeployer) deployer).getExpressionManager());
+        originalDeployer.setIdGenerator(((SimulatingBpmnDeployer) deployer).getIdGenerator());
+        return true;
+      }      
+      return false;
+    });
+    pimpl.getDeployers().add(originalDeployer);
+    
+    pimpl.getCustomPreBPMNParseListeners().removeIf(listener -> (listener instanceof SimulationParseListener));
+  }
 
   public static SimulatingBpmnDeployer getSimulationBpmnDeployer() {
     List<Deployer> deployers = getProcessEngineConfiguration().getDeployers();

--- a/src/main/java/com/camunda/consulting/simulator/SimulatorPlugin.java
+++ b/src/main/java/com/camunda/consulting/simulator/SimulatorPlugin.java
@@ -66,9 +66,11 @@ public class SimulatorPlugin implements ProcessEnginePlugin {
       }      
       return false;
     });
-    pimpl.getDeployers().add(originalDeployer);
-    
+   
     pimpl.getCustomPreBPMNParseListeners().removeIf(listener -> (listener instanceof SimulationParseListener));
+    originalDeployer.getBpmnParser().getParseListeners().removeIf(listener -> (listener instanceof SimulationParseListener));
+    
+    pimpl.getDeployers().add(originalDeployer);
   }
 
   public static SimulatingBpmnDeployer getSimulationBpmnDeployer() {

--- a/src/main/java/com/camunda/consulting/simulator/SimulatorPlugin.java
+++ b/src/main/java/com/camunda/consulting/simulator/SimulatorPlugin.java
@@ -72,6 +72,24 @@ public class SimulatorPlugin implements ProcessEnginePlugin {
     
     pimpl.getDeployers().add(originalDeployer);
   }
+  
+  public static void setProcessEngineElements() {
+    ProcessEngineConfigurationImpl pimpl = getProcessEngineConfiguration();
+    SimulationParseListener parseListener = new SimulationParseListener();
+    
+    for (Deployer deployer: pimpl.getDeployers()) {
+      if(deployer instanceof BpmnDeployer && !(deployer instanceof SimulatingBpmnDeployer)) {  
+        SimulatingBpmnDeployer simDeployer = new SimulatingBpmnDeployer((BpmnDeployer) deployer);
+        pimpl.getDeployers().add(simDeployer);
+        simDeployer.getBpmnParser().getParseListeners().add(parseListener);
+        pimpl.getDeployers().remove(deployer);
+      } 
+    }
+   
+    ArrayList<BpmnParseListener> parseListeners = new ArrayList<>();
+    pimpl.setCustomPreBPMNParseListeners(parseListeners);
+    parseListeners.add(new SimulationParseListener());
+  }
 
   public static SimulatingBpmnDeployer getSimulationBpmnDeployer() {
     List<Deployer> deployers = getProcessEngineConfiguration().getDeployers();

--- a/src/test/java/com/camunda/consulting/simulator/SimulationExecutorTest.java
+++ b/src/test/java/com/camunda/consulting/simulator/SimulationExecutorTest.java
@@ -77,7 +77,7 @@ public class SimulationExecutorTest {
     assertThat(count).isEqualTo(61);
     
     //redeployment, should not complete it afterwards
-    SimulatorPlugin.resetProcessEngineElements();
+    SimulatorPlugin.resetProcessEngine();
 
     rule.getProcessEngine().getRepositoryService().createDeployment() 
         .addClasspathResource("stopSimulationAfterRedeployment.bpmn")
@@ -93,7 +93,7 @@ public class SimulationExecutorTest {
     assertThat(processInstance).isNotEnded();
     
     // re-activate again
-    SimulatorPlugin.setProcessEngineElements();
+    SimulatorPlugin.alterProcessEngine();
   }
   
   @Test

--- a/src/test/java/com/camunda/consulting/simulator/SimulationExecutorTest.java
+++ b/src/test/java/com/camunda/consulting/simulator/SimulationExecutorTest.java
@@ -11,6 +11,7 @@ import org.apache.ibatis.logging.LogFactory;
 import org.assertj.core.api.Condition;
 import org.camunda.bpm.BpmPlatform;
 import org.camunda.bpm.container.RuntimeContainerDelegate;
+import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.history.HistoricProcessInstance;
 import org.camunda.bpm.engine.history.HistoricVariableInstance;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
@@ -19,6 +20,7 @@ import org.camunda.bpm.engine.test.Deployment;
 import org.camunda.bpm.engine.test.ProcessEngineRule;
 import org.joda.time.DateTime;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -81,7 +83,7 @@ public class SimulationExecutorTest {
         .addClasspathResource("stopSimulationAfterRedeployment.bpmn")
         .deploy();
 
-    rule.getProcessEngine().getRuntimeService().startProcessInstanceByKey("redeployment", "A-234");
+    ProcessInstance processInstance = rule.getProcessEngine().getRuntimeService().startProcessInstanceByKey("redeployment", "A-234");
     
     SimulationExecutor.execute(DateTime.now().toDate(), DateTime.now().plusSeconds(10).toDate());
     count = historyService().createHistoricProcessInstanceQuery().processDefinitionKey("redeployment").completed().count();
@@ -89,6 +91,10 @@ public class SimulationExecutorTest {
     
     ProcessEngineConfigurationImpl processEngineConfigurationImpl = (ProcessEngineConfigurationImpl) rule.getProcessEngine().getProcessEngineConfiguration();
     assertThat(processEngineConfigurationImpl.getJobHandlers());
+    
+    rule.getProcessEngine().getRuntimeService().deleteProcessInstance(processInstance.getId(), "Yee");
+    SimulatorPlugin.setProcessEngineElements();
+    SimulationExecutor.restartSimulation();
   }
   
   @Test

--- a/src/test/resources/stopSimulationAfterRedeployment.bpmn
+++ b/src/test/resources/stopSimulationAfterRedeployment.bpmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_156pm71" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.1.2">
+  <bpmn:process id="redeployment" isExecutable="true">
+    <bpmn:endEvent id="EndEvent_09m2mbe">
+      <bpmn:incoming>SequenceFlow_0aqm6yp</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="ServiceTask_0myurb0" name="External Task" camunda:type="external" camunda:topic="foo">
+      <bpmn:extensionElements>
+        <camunda:properties>
+          <camunda:property name="simNextFire" value="${g.now()}" />
+        </camunda:properties>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0vwzd6c</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0aqm6yp</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0vwzd6c" sourceRef="StartEvent_11gxbkn" targetRef="ServiceTask_0myurb0" />
+    <bpmn:sequenceFlow id="SequenceFlow_0aqm6yp" sourceRef="ServiceTask_0myurb0" targetRef="EndEvent_09m2mbe" />
+    <bpmn:startEvent id="StartEvent_11gxbkn">
+      <bpmn:extensionElements>
+        <camunda:properties>
+          <camunda:property name="simNextFire" value="${g.nowPlusMinutes(1)}" />
+        </camunda:properties>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>SequenceFlow_0vwzd6c</bpmn:outgoing>
+    </bpmn:startEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="redeployment">
+      <bpmndi:BPMNShape id="EndEvent_09m2mbe_di" bpmnElement="EndEvent_09m2mbe">
+        <dc:Bounds x="392" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0myurb0_di" bpmnElement="ServiceTask_0myurb0">
+        <dc:Bounds x="242" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0vwzd6c_di" bpmnElement="SequenceFlow_0vwzd6c">
+        <di:waypoint x="192" y="121" />
+        <di:waypoint x="242" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0aqm6yp_di" bpmnElement="SequenceFlow_0aqm6yp">
+        <di:waypoint x="342" y="121" />
+        <di:waypoint x="392" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="StartEvent_0qpgutm_di" bpmnElement="StartEvent_11gxbkn">
+        <dc:Bounds x="156" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
- add reset method to:

  - be able to redeploy processes and run them without simulation manipulating the new instances
  - still simulate and complete older process instances