### PR TITLE
Remove task listeners more carefully - keep built-in listeners.

### DIFF
--- a/src/main/java/com/camunda/consulting/simulator/modding/SimulationParseListener.java
+++ b/src/main/java/com/camunda/consulting/simulator/modding/SimulationParseListener.java
@@ -141,8 +141,20 @@ public class SimulationParseListener implements BpmnParseListener {
 
   @Override
   public void parseUserTask(Element userTaskElement, ScopeImpl scope, ActivityImpl activity) {
-    checkKeepListeners(userTaskElement, activity);
+    boolean keepListeners = checkKeepListeners(userTaskElement, activity);
     addPayloadGeneratingListener(activity);
+
+    if (!keepListeners) {
+      TaskDefinition taskDefinition = ((UserTaskActivityBehavior) activity.getActivityBehavior()).getTaskDefinition();
+      taskDefinition.getTaskListeners().forEach((eventName, taskListeners)->{
+        for (Iterator<TaskListener> i = taskListeners.iterator(); i.hasNext(); ) {
+          TaskListener taskListener = i.next();
+          if ( ! taskDefinition.getBuiltinTaskListeners(eventName).contains(taskListener)) {
+            i.remove();
+          }
+        }
+      });
+    }
 
     addUserTaskCompleteJobCreatingListener(activity);
     addUserTaskClaimJobCreatingListener(activity);

--- a/src/main/java/com/camunda/consulting/simulator/modding/SimulationParseListener.java
+++ b/src/main/java/com/camunda/consulting/simulator/modding/SimulationParseListener.java
@@ -22,6 +22,7 @@ import org.camunda.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.camunda.bpm.engine.impl.pvm.process.ActivityImpl;
 import org.camunda.bpm.engine.impl.pvm.process.ScopeImpl;
 import org.camunda.bpm.engine.impl.pvm.process.TransitionImpl;
+import org.camunda.bpm.engine.impl.task.TaskDefinition;
 import org.camunda.bpm.engine.impl.util.xml.Element;
 import org.camunda.bpm.engine.impl.variable.VariableDeclaration;
 import org.slf4j.Logger;

--- a/src/test/java/com/camunda/consulting/simulator/SimulationParseListenerTest.java
+++ b/src/test/java/com/camunda/consulting/simulator/SimulationParseListenerTest.java
@@ -52,7 +52,7 @@ public class SimulationParseListenerTest {
         .doesNotContainKey("startEventExecutionStartListenerExecuted") //
         .doesNotContainKey("executionStartListenerExecuted") //
         .doesNotContainKey("executionEndListenerExecuted") //
-        .containsKey("taskCreateListenerExecuted") //
+        .doesNotContainKey("taskCreateListenerExecuted") //
         .doesNotContainKey("executionEndListenerOnBoundaryInMultiInstanceExecuted");
     assertThat(processInstance).variables() //
         .containsKey("implementationKept") //


### PR DESCRIPTION
I think this approach is less invasive since it still allows to strip or keep (via property) custom task listeners, while if always keeps built-in task listeners.