### PR TITLE
chore(ci): Remove settings.githubSSHCredentials parameter from the pipeline, it’s moved to getDefaultsForMavenDeploy()

### DIFF
--- a/.ci.consulting
+++ b/.ci.consulting
@@ -1,5 +1,4 @@
 @Library(["camunda-ci", "camunda-consulting"]) _
 
 def settings = getDefaultsForMavenDeploy() // function from `camunda-consulting` Library
-settings.githubSSHCredentials = 'github_camunda_consulting_ssh'
 buildMavenAndDeploy settings               // function from `camunda-ci` 


### PR DESCRIPTION
Related shared library change: https://github.com/camunda-consulting/jenkins-shared-library/pull/6